### PR TITLE
ci: remove reference to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,61 @@ on:
     branches: [main]
 
 jobs:
-  Release:
-    name: Release
-    uses: equinor/ops-actions/.github/workflows/python-release.yml@main # TODO: pin to a release tag
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-24.04
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
+      contents: write # Required to update changelog files.
+      issues: write # Required to label issues.
+      pull-requests: write # Required to create release PRs.
+    steps:
+      - name: Release Please
+        id: release-please
+        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
+      paths_released: ${{ steps.release-please.outputs.paths_released }}
+
+  python-build:
+    name: Python Build
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    strategy:
+      matrix:
+        path: ${{ fromJSON(needs.release-please.outputs.paths_released) }}
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      contents: read # Required to checkout the repository.
+      id-token: write # Required for PyPI Trusted Publishing.
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ matrix.path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependecies
+        run: python -m pip install --upgrade pip build
+
+      - name: Generate distributions
+        # The build command will generate a source distribution (`.tar.gz` file)
+        # and a built distribution (`.whl` file) in the `dist` directory.
+        # Ref: https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          packages-dir: ${{ matrix.path }}/dist


### PR DESCRIPTION
Reusable workflows cannot currently be used as the workflow in a Trusted Publisher ([ref.](https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github)).

Copy contents of reusable workflow directly into this repository.

Release-As: dataorc 0.1.1