### PR TITLE
ci: run Ruff Linter and Formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to checkout the repository.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Run Ruff Linter
+        run: ruff check --output-format=github .
+
+      - name: Run Ruff Formatter
+        run: ruff format --check


### PR DESCRIPTION
Run Ruff Linter and Formatter on pull request to highlight errors and ensure stylistic consistency before merging to branch main.

Run on push to branch main (i.e., merge to branch main) to ensure all squash commits pass CI checks. We can add a badge to the README later that displays the status of all checks on branch main.