### PR TITLE
docs: initialize documentation structure and version matrix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# DataOrc Documentation
+
+Welcome to the DataOrc documentation. This site provides versioned documentation for the repository packages.
+
+## Version Matrix
+
+See the [version matrix](version-matrix.md) for an overview of package versions.
+
+_Detailed package documentation will be added in a future branch._

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs==1.6.0
+mkdocs-material==9.5.18
+mkdocstrings==0.24.3
+mkdocstrings-python==1.10.5
+mkdocs-git-revision-date-localized-plugin==1.2.5

--- a/docs/version-matrix.md
+++ b/docs/version-matrix.md
@@ -1,0 +1,5 @@
+# Version Matrix
+
+| Package | Version |
+|---------|---------|
+| dataorc | 0.1.1 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ site_description: Unified documentation for DataOrc packages
 ## 1. Leave a static placeholder (current approach)
 ## 2. Use mkdocs-macros-plugin or mike for versioned site_url logic
 ## 3. Inject site_url via RTD 'Advanced Settings' or build step
-site_url: https://dataorc.readthedocs.io/
 repo_url: https://github.com/equinor/dataorc
 repo_name: equinor/dataorc
 
@@ -16,7 +15,6 @@ theme:
   features:
     - navigation.instant
     - navigation.sections
-    - content.code.copy
 
 plugins:
   - search
@@ -27,8 +25,6 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: true
-  - tables
-  - fenced_code
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,35 @@
+site_name: DataOrc Documentation
+site_description: Unified documentation for DataOrc packages
+## Canonical site URL
+## Read the Docs provides READTHEDOCS_CANONICAL_URL env variable at build time, but
+## the plain MkDocs YAML parser doesn't understand !ENV without a plugin.
+## Options:
+## 1. Leave a static placeholder (current approach)
+## 2. Use mkdocs-macros-plugin or mike for versioned site_url logic
+## 3. Inject site_url via RTD 'Advanced Settings' or build step
+site_url: https://dataorc.readthedocs.io/
+repo_url: https://github.com/equinor/dataorc
+repo_name: equinor/dataorc
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+
+plugins:
+  - search
+  - git-revision-date-localized:
+      fallback_to_build_date: true
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - fenced_code
+
+nav:
+  - Home: index.md
+  - Version Matrix: version-matrix.md

--- a/scripts/update_version_matrix.py
+++ b/scripts/update_version_matrix.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regenerate docs/version-matrix.md from package pyproject.toml files.
+
+Usage:
+  python scripts/update_version_matrix.py            # rewrite file
+  python scripts/update_version_matrix.py --check    # exit 1 if file differs
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import tomllib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOC_FILE = REPO_ROOT / "docs" / "version-matrix.md"
+PACKAGES_DIRS = [REPO_ROOT / "packages", REPO_ROOT]  # include root project
+
+
+def find_pyprojects() -> list[pathlib.Path]:
+    pyprojects: list[pathlib.Path] = []
+    for base in PACKAGES_DIRS:
+        if base.is_dir():
+            if (base / "pyproject.toml").exists() and base != REPO_ROOT:
+                # package directory that directly contains pyproject
+                pass
+            # Search immediate children for pyproject.toml
+            for child in base.iterdir():
+                if child.is_dir():
+                    pp = child / "pyproject.toml"
+                    if pp.exists():
+                        pyprojects.append(pp)
+    # Add root pyproject if present
+    root_pp = REPO_ROOT / "pyproject.toml"
+    if root_pp.exists():
+        pyprojects.append(root_pp)
+    return pyprojects
+
+
+def parse_project(path: pathlib.Path) -> tuple[str, str]:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    name = data.get("project", {}).get("name", path.parent.name)
+    version = data.get("project", {}).get("version", "0.0.0")
+    return name, version
+
+
+def generate_table(rows: list[tuple[str, str]]) -> str:
+    header = ["# Version Matrix", "", "| Package | Version |", "|---------|---------|"]
+    body = [f"| {name} | {version} |" for name, version in sorted(rows)]
+    return "\n".join(header + body + [""])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Fail if matrix out of date")
+    args = parser.parse_args()
+
+    rows = [parse_project(p) for p in find_pyprojects()]
+    content = generate_table(rows)
+
+    if DOC_FILE.exists():
+        existing = DOC_FILE.read_text(encoding="utf-8")
+    else:
+        existing = ""
+
+    if args.check:
+        if existing != content:
+            print("version-matrix.md is outdated. Run the update script.", file=sys.stderr)
+            return 1
+        print("version-matrix.md up to date.")
+        return 0
+
+    DOC_FILE.write_text(content, encoding="utf-8")
+    print(f"Updated {DOC_FILE.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request adds initial documentation infrastructure for the DataOrc project, including configuration for MkDocs and Read the Docs, as well as automation for maintaining a version matrix of packages. The main themes are documentation setup, tooling configuration, and automation for keeping documentation up to date.

**Documentation infrastructure:**

* Added `.readthedocs.yaml` to configure Read the Docs builds using Python 3.12 and MkDocs with dependencies from `docs/requirements.txt`.
* Created `mkdocs.yml` to configure the MkDocs documentation site, including theme, plugins, navigation, and repository links.
* Added `docs/index.md` as the documentation homepage, with a link to the version matrix and a placeholder for future content.
* Added `docs/version-matrix.md` to display a table of package versions (currently listing `dataorc` version 0.1.1).

**Tooling and automation:**

* Added `docs/requirements.txt` specifying MkDocs and related plugins required for building the documentation.
* Introduced `scripts/update_version_matrix.py`, a script to automatically generate or check the `version-matrix.md` file based on `pyproject.toml` files found in the repository, ensuring the version matrix stays up to date.