### PR TITLE
docs: add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dataorc
 
+[![CI](https://github.com/equinor/dataorc/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/equinor/dataorc/actions/workflows/ci.yml)
+
 ## Contributing
 
 See [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
Add badge to repository that displays current status of the CI workflow. Will highlight if the CI workflow is failing for the code currently in branch main.