### PR TITLE
chore: add code of conduct and security policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of conduct
+
+This project has adopted, and adheres to, the common [Equinor open source code of conduct](https://github.com/equinor/opensource/blob/master/CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security policy
+
+If you discover a security vulnerability in this project, please follow these steps to responsibly disclose it:
+
+1. **Do not** create a public GitHub issue for the vulnerability
+1. Follow our guideline for Responsible Disclosure Policy at <https://www.equinor.com/about-us/csirt> to report the issue
+
+The following information will help us triage your report more quickly:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer all communications to be in English.


### PR DESCRIPTION
Add code of conduct and security policy, as described in #11:

- `CODE_OF_CONDUCT.md` refers to the Equinor open source code of conduct.
- `SECURITY.md` based on the Equinor template for public repositories.