### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # Contributing guidelines
 
+This document provides guidelines for contributing to the dataorc project.
+
+## Requesting changes
+
+[Create a new issue](https://github.com/equinor/dataorc/issues/new/choose).
+
+## Making changes
+
+1. Create a new branch. For external contributors, create a fork.
+1. Make your changes.
+1. Commit your changes.
+
+    Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for semantic commit messages.
+
+1. Create a pull request to merge your changes into branch `main`.
+
 ## Add new package
 
 Adding and publishing a new package requires some initial setup:


### PR DESCRIPTION
Add initial contributing guidelines, as described in #11, providing instructions on how to request and make changes.