### PR TITLE
docs: add changelog tab

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,0 +1,9 @@
+<!-- Embed content from the CHANGELOG.md file. -->
+
+<!--
+Disable markdownlint rule MD041: "First line in a file should be a top-level heading".
+The CHANGELOG.md file already contains a top-level heading.
+-->
+<!-- markdownlint-disable MD041 -->
+
+--8<-- "CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,11 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: true
+  # Enable the Snippets extension to add the ability to embed content from
+  # external files.
+  # Ref: https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets
+  - pymdownx.snippets
 
 nav:
   - Home: index.md
+  - Changelog: changelog/index.md


### PR DESCRIPTION
Add a new tab "Changelog" at the top of the page, containing the contents of the `CHANGELOG.md` file at the root of this repository.