### PR TITLE
chore: add dependencies on root package for all other packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "dataorc"
 version = "0.1.1"
-description = "Metapackage installing all other modules in dataorc family"
+description = "Metapackage installing all other packages in dataorc family"
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration to better define the `dataorc` package as a metapackage and improve its metadata. The most important change is specifying the dependencies. 

**Project metadata improvements:**

* Added a `description`, `readme`, and `authors` section to provide clearer package information.
* Specified `requires-python` to require Python 3.12 or newer.
* Added a `dependencies` section to declare `dataorc-utils` as a required dependency.

**Build configuration:**

* Added a `[tool.hatch.build.targets.wheel]` section with an empty `packages` list, clarifying build behavior for the metapackage.