### PR TITLE
feat: update changelog structure and add dataorc-utils changelog

### DIFF
--- a/docs/changelog/dataorc-utils.md
+++ b/docs/changelog/dataorc-utils.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD041 -->
+--8<-- "packages/dataorc-utils/CHANGELOG.md"

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -7,3 +7,4 @@ The CHANGELOG.md file already contains a top-level heading.
 <!-- markdownlint-disable MD041 -->
 
 --8<-- "CHANGELOG.md"
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,4 +63,6 @@ nav:
           - CorePipelineConfig: packages/dataorc-utils/config/core_pipeline_config.md
           - PipelineParameterManager: packages/dataorc-utils/config/pipeline_parameter_manager.md
           - Defaults and validation: packages/dataorc-utils/config/defaults_and_validation.md
-  - Changelog: changelog/index.md
+  - Changelog:
+    - dataorc: changelog/index.md
+    - dataorc-utils: changelog/dataorc-utils.md


### PR DESCRIPTION
This pull request updates the documentation to improve the organization and accessibility of changelogs for different packages. The main changes involve splitting the changelog section to provide separate entries for `dataorc` and `dataorc-utils`, and including the `dataorc-utils` changelog content directly in the docs.

Changelog documentation improvements:

- added separate page for dataorc-utils changelog, so that releases will be reflected independently of packages in changelog