### PR TITLE
chore: configure code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @equinor/dataorc-maintainers


### PR DESCRIPTION
Configure the dataorc maintainers team as owner of entire codebase (`*`). Allows us to configure this repository to require PR reviews from this team by default.