### PR TITLE
chore(utils): require Python >=3.11

### DIFF
--- a/packages/dataorc-utils/pyproject.toml
+++ b/packages/dataorc-utils/pyproject.toml
@@ -7,7 +7,7 @@ name = "dataorc-utils"
 version = "0.1.0"
 description = "Utility functions for ETL operations"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Updated Python version requirement from 3.12 to 3.11.