### PR TITLE
feat(utils): update parse_args to accept mixed required and optional arguments

### DIFF
--- a/docs/packages/dataorc-utils/databricks/parameters.md
+++ b/docs/packages/dataorc-utils/databricks/parameters.md
@@ -9,12 +9,12 @@ When running Python wheel tasks in Databricks jobs, we set parameters as part of
 Parameters:
 
 - `description` (str): Description shown in the help output.
-- `arguments` (list[str]): List of argument names to parse. Each name becomes a
-  required `--name` CLI flag.
+- `arguments` (list[str] | dict[str, bool]): Either a list of argument names (all required), 
+  or a dict mapping argument names to boolean `required` flags. Each name becomes a `--name` CLI flag.
 
 Returns an `argparse.Namespace` with each argument accessible as an attribute.
 
-## Example (wheel task entry point)
+## Example 1: All required arguments (list)
 
 ```python
 from dataorc_utils.databricks import parse_args
@@ -33,4 +33,20 @@ the script will print:
 
 ```text
 Running on analytics.public.events
+```
+
+## Example 2: Mixed required and optional arguments (dict)
+
+```python
+from dataorc_utils.databricks import parse_args
+
+def main():
+    args = parse_args("ETL Job", {
+        "database": True,   # required
+        "schema": False,    # optional
+        "mode": False       # optional
+    })
+    
+if __name__ == "__main__":
+    main()
 ```

--- a/packages/dataorc-utils/src/dataorc_utils/databricks/args.py
+++ b/packages/dataorc-utils/src/dataorc_utils/databricks/args.py
@@ -7,32 +7,45 @@ in Databricks jobs.
 from __future__ import annotations
 
 from argparse import ArgumentParser, Namespace
+from typing import Dict, Iterable, Union
 
 
-def parse_args(description: str, arguments: list[str]) -> Namespace:
+def parse_args(
+    description: str,
+    arguments: Union[Iterable[str], Dict[str, bool]],
+) -> Namespace:
     """Parse command-line arguments for a Databricks wheel task.
 
-    When running Python wheel tasks in Databricks, job parameters are passed
-    as command-line arguments. This helper creates an argument parser with
-    the specified arguments and returns the parsed values.
+    Accepts either an iterable of argument names (all required), or a dict
+    mapping argument names to a boolean `required` flag. Each argument is
+    exposed as a `--name` CLI option and parsed as `str`.
 
     Args:
         description: Description shown in help output for the argument parser.
-        arguments: List of argument names to parse (e.g., ["database", "schema"]).
-            Each name becomes a required ``--name`` argument.
+        arguments: Either a list/iterable of argument names (e.g., ["db"]),
+            which will be treated as required, or a dict mapping names to a
+            boolean indicating whether the argument is required
+            (e.g., {"db": True, "schema": False}).
 
     Returns:
         Namespace with parsed arguments accessible as attributes.
 
-    Example:
-        >>> # Called with: --database mydb --schema public
-        >>> args = parse_args("ETL Job", ["database", "schema"])
-        >>> print(args.database, args.schema)
-        mydb public
+    Examples:
+        # All required args
+        args = parse_args("ETL Job", ["database", "schema"])  # both required
+
+        # Per-arg required flags
+        args = parse_args("ETL Job", {"database": True, "schema": False})
     """
     parser = ArgumentParser(description=description)
 
-    for name in arguments:
-        parser.add_argument(f"--{name}", type=str, required=True)
+    # Normalize arguments into a mapping of name -> required flag
+    if isinstance(arguments, dict):
+        arg_map = arguments
+    else:
+        arg_map = {name: True for name in arguments}
+
+    for name, required in arg_map.items():
+        parser.add_argument(f"--{name}", type=str, required=bool(required))
 
     return parser.parse_args()


### PR DESCRIPTION
This pull request enhances the flexibility of the `parse_args` utility for Databricks wheel tasks by allowing arguments to be specified as either a list (all required) or a dictionary (with per-argument required flags). It also updates the documentation with clearer examples for both usage patterns.

**Improvements to argument parsing:**

* [`packages/dataorc-utils/src/dataorc_utils/databricks/args.py`](diffhunk://#diff-4afc801d45f88ac18f22142e9dc7d618892409b4619adac35a8b9fa70b8f3f0fR10-R49): Updated `parse_args` to accept either an iterable of argument names (all required) or a dict mapping argument names to booleans indicating if each is required, making CLI argument specification more flexible.

**Documentation updates:**

* [`docs/packages/dataorc-utils/databricks/parameters.md`](diffhunk://#diff-91b525a8c6a67c53ed2a2c2ae3e7cc87abd52f3070b3e858f596626cf3434094L12-R17): Updated documentation to explain the new argument format for `parse_args`, including examples for both all-required (list) and mixed required/optional (dict) usage patterns. 