### PR TITLE
feat: introduce dictionary functionality for environment variables access

### DIFF
--- a/packages/dataorc-utils/src/dataorc_utils/config/models.py
+++ b/packages/dataorc-utils/src/dataorc_utils/config/models.py
@@ -54,8 +54,21 @@ class CorePipelineConfig:
 
     # Flexible infrastructure variables (datalake_name, container, Azure IDs, etc.)
     env_vars: dict[str, str] = field(default_factory=dict)
-    # Convenience properties that return the canonical lake path for each layer.
 
+    # Allow the CorePipelineConfig to behave like a read-only mapping instead of exposing the env_vars directly
+    def get(self, key: str) -> str:
+        val = self.env_vars.get(key)
+        if not isinstance(val, str):
+            # This is a non-standard get() implementation that raises if missing/invalid since normal Mapping.get() implementation would return 'None'
+            raise RuntimeError(
+                f"Missing or invalid environment configuration variable '{key}'"
+            )
+        return val
+
+    def __getitem__(self, key: str) -> str:
+        return self.get(key)
+
+    # Convenience properties that return the canonical lake path for each layer.
     def get_lake_path(
         self,
         layer: str,


### PR DESCRIPTION
Introduce dictionary functionality for environment variables to avoid exposing CorePipelineConfig class internals. Just a simplification to allow the caller (DSISClientManager) to have access to environment variables directly from the configuration instance and not its internal dictionary. 

Will allow for future removal of the DSISClientManager._require_env_var() method and allow for simplification of access/checking of environment variables from CorePipelineConfig. 