### PR TITLE
feat(utils): add support for constructing AdlsLakeFileSystem from abfss URI

### DIFF
--- a/docs/packages/dataorc-utils/lake/index.md
+++ b/docs/packages/dataorc-utils/lake/index.md
@@ -95,6 +95,23 @@ if fs.exists("old_file.txt"):
     fs.delete("old_file.txt")
 ```
 
+#### From an `abfss://` URI
+
+If you already have a full `abfss://` path (common in Databricks and ADF), you can
+construct an instance directly from the URI:
+
+```python
+from dataorc_utils.lake import AdlsLakeFileSystem
+
+fs = AdlsLakeFileSystem.from_abfss_uri(
+    "abfss://bronze@testdatadevsc.dfs.core.windows.net/sales/orders"
+)
+
+fs.write_json("config.json", {"version": 1, "status": "complete"})
+```
+
+This parses the container, storage account, and path from the URI automatically.
+
 Authentication uses `DefaultAzureCredential` by default, which supports
 Managed Identity, Azure CLI (`az login`), and environment variables.
 You can also pass a custom credential via the `credential` parameter
@@ -163,6 +180,21 @@ Direct connection to ADLS Gen2 — no mounts or Databricks utilities required.
 | `account_url` | `str` | Full DFS endpoint, e.g. `"https://<account>.dfs.core.windows.net"` |
 | `container` | `str` | File-system / container name, e.g. `"bronze"` |
 | `base_path` | `str` | Optional prefix inside the container prepended to every path. Defaults to `""`. |
+| `credential` | `Any \| None` | Any Azure credential accepted by the SDK. Defaults to `DefaultAzureCredential()`. |
+
+#### `from_abfss_uri` (classmethod)
+
+Construct an `AdlsLakeFileSystem` from a full `abfss://` URI.
+
+```python
+fs = AdlsLakeFileSystem.from_abfss_uri(
+    "abfss://bronze@mystorageaccount.dfs.core.windows.net/raw/pipeline"
+)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `uri` | `str` | Full ABFSS path, e.g. `"abfss://{container}@{account}.dfs.core.windows.net/{path}"` |
 | `credential` | `Any \| None` | Any Azure credential accepted by the SDK. Defaults to `DefaultAzureCredential()`. |
 
 #### Methods

--- a/packages/dataorc-utils/src/dataorc_utils/lake/adls_filesystem.py
+++ b/packages/dataorc-utils/src/dataorc_utils/lake/adls_filesystem.py
@@ -12,6 +12,7 @@ Requires the ``azure`` extra::
 from __future__ import annotations
 
 import logging
+import urllib.parse
 from typing import Any
 
 from azure.identity import DefaultAzureCredential
@@ -44,6 +45,35 @@ class AdlsLakeFileSystem(LakeFileSystemProtocol):
         fs.write_json("data.json", {"key": "value"})
         data = fs.read_json("data.json")
     """
+
+    @classmethod
+    def from_abfss_uri(
+        cls, uri: str, credential: Any | None = None
+    ) -> AdlsLakeFileSystem:
+        """Construct from an ``abfss://`` URI.
+
+        Args:
+            uri: Full ABFSS path, e.g.
+                ``"abfss://{container}@{account}.dfs.core.windows.net/{path}"``
+            credential: Any Azure credential accepted by the SDK.
+                Defaults to ``DefaultAzureCredential()``.
+        """
+        parsed = urllib.parse.urlparse(uri)
+        if parsed.scheme != "abfss":
+            msg = f"Expected 'abfss' scheme, got {parsed.scheme!r}"
+            raise ValueError(msg)
+        container = parsed.username
+        if not container or not parsed.hostname:
+            msg = f"Invalid abfss URI: {uri!r}"
+            raise ValueError(msg)
+        account_url = f"https://{parsed.hostname}"
+        base_path = parsed.path.lstrip("/")
+        return cls(
+            account_url=account_url,
+            container=container,
+            base_path=base_path,
+            credential=credential,
+        )
 
     def __init__(
         self,

--- a/packages/dataorc-utils/tests/test_lake_filesystem.py
+++ b/packages/dataorc-utils/tests/test_lake_filesystem.py
@@ -88,12 +88,31 @@ def adls_fs():
         )
 
 
-@pytest.fixture(params=["lake", "adls"])
-def fs(request, lake_fs, adls_fs):
-    """Parametrized fixture that yields both filesystem implementations."""
+@pytest.fixture
+def adls_abfss_fs():
+    """AdlsLakeFileSystem constructed via from_abfss_uri."""
+    with (
+        patch(
+            "dataorc_utils.lake.adls_filesystem.DataLakeServiceClient"
+        ) as mock_service_cls,
+        patch("dataorc_utils.lake.adls_filesystem.DefaultAzureCredential"),
+    ):
+        mock_service = mock_service_cls.return_value
+        mock_service.get_file_system_client.return_value = _InMemoryFsClient()
+
+        yield AdlsLakeFileSystem.from_abfss_uri(
+            "abfss://test@fake.dfs.core.windows.net/"
+        )
+
+
+@pytest.fixture(params=["lake", "adls", "adls_abfss"])
+def fs(request, lake_fs, adls_fs, adls_abfss_fs):
+    """Parametrized fixture that yields all filesystem implementations."""
     if request.param == "lake":
         return lake_fs
-    return adls_fs
+    if request.param == "adls":
+        return adls_fs
+    return adls_abfss_fs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**New feature: ABFSS URI support**
- Added a `from_abfss_uri` classmethod to `AdlsLakeFileSystem` that parses an `abfss://` URI and constructs an instance using the container, storage account, and path extracted from the URI. This method validates the URI scheme and raises errors for invalid formats.

**Documentation updates**
- Expanded the usage documentation in `docs/packages/dataorc-utils/lake/index.md` to describe how to use the new `from_abfss_uri` method, including code examples and a new section in the API reference table. 

**Testing improvements**
- Added a new test fixture, `adls_abfss_fs`, to create an `AdlsLakeFileSystem` using the `from_abfss_uri` method, and updated the main parametrized fixture to include this new implementation in the test suite.